### PR TITLE
空コメントだと詳細ページに遷移できるように設定

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,8 @@
 class CommentsController < ApplicationController
   def create
     @comment = Comment.new(comment_params)
-    
+    @comments = @comment.prototype.comments.includes(:user)
+
     if @comment.save
       redirect_to prototype_path(@comment.prototype)
     else


### PR DESCRIPTION
# What
空コメントだと詳細ページに遷移できるように設定した

# Why
空コメントだとエラーメッセージが表示されてしまっていたため